### PR TITLE
Adding Ngrok Tunnels

### DIFF
--- a/Web-API/Gruntfile.js
+++ b/Web-API/Gruntfile.js
@@ -17,11 +17,13 @@ module.exports = function (grunt) {
     cdnify: 'grunt-google-cdn',
     protractor: 'grunt-protractor-runner',
     buildcontrol: 'grunt-build-control',
-    ngconstant: 'grunt-ng-constant'
+    ngconstant: 'grunt-ng-constant',
+    ngrok: 'grunt-ngrok'
   });
 
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
+  grunt.loadNpmTasks('grunt-ngrok');
 
   // Define the configuration for all the tasks
   grunt.initConfig({
@@ -33,6 +35,30 @@ module.exports = function (grunt) {
       client: require('./bower.json').appPath || 'client',
       server: 'server',
       dist: 'dist'
+    },
+    ngrok: {
+      options: {
+        authToken: '3aT9NRB8axfgBNxfjheGq_68M2wymgatztYut6xYLaX',
+        log: 'stdout',
+        onConnected: function(url) {
+            grunt.log.writeln('Opened tunnel at %s', url);
+            if (url.match(/tcp\:\/\//)) {
+              process.env['STREAMSERVER_URL'] = url.split('tcp://')[1];
+            }
+        }
+      },
+      tunnels: {
+        webserver: {
+          proto: 'http',
+          addr: 9000,
+          subdomain: 'gabeharmsWebServer'
+        },
+        streamserver: {
+          proto: 'tcp',
+          addr: 8084,
+          subdomain: 'gabeharmsStreamServer'
+        },
+      }
     },
     express: {
       options: {
@@ -688,6 +714,7 @@ module.exports = function (grunt) {
       'injector',
       'wiredep:client',
       'postcss',
+      'ngrok',
       'express:dev',
       'wait',
       'open',

--- a/Web-API/client/app/common/directives/live-stream.directive.js
+++ b/Web-API/client/app/common/directives/live-stream.directive.js
@@ -1,0 +1,35 @@
+angular.module('webApiApp')
+  .controller('LiveStreamCtrl', liveStreamCtrl)
+  .directive('liveStream', liveStreamDirective);
+
+
+function liveStreamCtrl($scope) {
+  var viewModel = this; // jshint ignore:line
+
+  /** Directive Variables **/
+  viewModel.token = $scope.token;
+
+  /** Directive Functions **/
+
+  _initController();
+
+    /****** Implementation ******/
+  function _initController() {
+    var client = new WebSocket( 'ws://0.tcp.ngrok.io:14066/' + viewModel.token);
+    var canvas = document.getElementById('videoCanvas');
+    var player = new jsmpeg(client, {canvas:canvas});
+
+  }
+}
+
+function liveStreamDirective() {
+  return {
+    restrict: 'E',
+    scope: {
+      token: '=token'
+    },
+    templateUrl: 'app/common/partials/live-stream.partial.html',
+    controller: 'LiveStreamCtrl',
+    controllerAs: 'liveStreamVM'
+  };
+}

--- a/Web-API/client/app/common/directives/live-stream.directive.js
+++ b/Web-API/client/app/common/directives/live-stream.directive.js
@@ -3,22 +3,24 @@ angular.module('webApiApp')
   .directive('liveStream', liveStreamDirective);
 
 
-function liveStreamCtrl($scope) {
+function liveStreamCtrl($scope, $timeout) {
   var viewModel = this; // jshint ignore:line
 
   /** Directive Variables **/
   viewModel.token = $scope.token;
+  viewModel.name = $scope.name;
 
   /** Directive Functions **/
 
-  _initController();
+  $timeout(_initController, 0);
 
     /****** Implementation ******/
   function _initController() {
-    var client = new WebSocket( 'ws://0.tcp.ngrok.io:14066/' + viewModel.token);
-    var canvas = document.getElementById('videoCanvas');
-    var player = new jsmpeg(client, {canvas:canvas});
-
+    angular.element(document).ready(function () {
+      var client = new WebSocket( 'ws://0.tcp.ngrok.io:14066/' + viewModel.token);
+      var canvas = document.getElementById('videoCanvas' + viewModel.name);
+      var player = new jsmpeg(client, {canvas:canvas});
+    });
   }
 }
 
@@ -26,10 +28,11 @@ function liveStreamDirective() {
   return {
     restrict: 'E',
     scope: {
-      token: '=token'
+      token: '=token',
+      name: '=name'
     },
     templateUrl: 'app/common/partials/live-stream.partial.html',
     controller: 'LiveStreamCtrl',
-    controllerAs: 'liveStreamVM'
+    controllerAs: 'liveStreamCtrl'
   };
 }

--- a/Web-API/client/app/common/directives/live-stream.directive.js
+++ b/Web-API/client/app/common/directives/live-stream.directive.js
@@ -3,7 +3,7 @@ angular.module('webApiApp')
   .directive('liveStream', liveStreamDirective);
 
 
-function liveStreamCtrl($scope, $timeout) {
+function liveStreamCtrl($scope, $timeout, streamUrlManager) {
   var viewModel = this; // jshint ignore:line
 
   /** Directive Variables **/
@@ -16,11 +16,19 @@ function liveStreamCtrl($scope, $timeout) {
 
     /****** Implementation ******/
   function _initController() {
-    angular.element(document).ready(function () {
-      var client = new WebSocket( 'ws://0.tcp.ngrok.io:14066/' + viewModel.token);
+
+    function _initPlayer(url) {
+      console.log(url); 
+      var client = new WebSocket( 'ws://' + url +  '/' + viewModel.token);
       var canvas = document.getElementById('videoCanvas' + viewModel.name);
       var player = new jsmpeg(client, {canvas:canvas});
-    });
+    }
+
+    function _showError() {
+      alert('Stream Server Could Not Be Found');
+    }
+    
+    streamUrlManager.getUrl().then(_initPlayer, _showError);
   }
 }
 

--- a/Web-API/client/app/common/modals/full-screen-video.controller.js
+++ b/Web-API/client/app/common/modals/full-screen-video.controller.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular.module('webApiApp')
+  .controller('FullScreenCtrl', fullScreenCtrl);
+
+function fullScreenCtrl($modalInstance, loginManager) {
+  var viewModel = this; // jshint ignore:line
+
+  /** Modal Variables **/
+  viewModel.token = null;
+
+  /** Modal Functions **/
+
+  _initController();
+
+  /****** Implementation ******/
+
+  function _initController() {
+    viewModel.token = loginManager.getToken();
+  }
+}
+
+

--- a/Web-API/client/app/common/modals/full-screen-video.html
+++ b/Web-API/client/app/common/modals/full-screen-video.html
@@ -6,20 +6,7 @@
   <form name="notificationInfo" novalidate>
 
     <section class="content details">
-      <canvas id="videoCanvas2" class="video-fill"  width="1280" height="720">
-          <p>
-            Please use a browser that supports the Canvas Element, like
-            <a href="http://www.google.com/chrome">Chrome</a>,
-            <a href="http://www.mozilla.com/firefox/">Firefox</a>,
-            <a href="http://www.apple.com/safari/">Safari</a> or Internet Explorer 10... Nottttt!
-          </p>
-        </canvas>
-        <script type="text/javascript">
-            // Setup the WebSocket connection and start the player
-            var client = new WebSocket( 'ws://localhost:8084/' );
-            var canvas = document.getElementById('videoCanvas2');
-            var player = new jsmpeg(client, {canvas:canvas});
-        </script>
+      <live-stream token="fullScreenCtrl.token" name="'fullScreenModal'" /> 
     </section>
     <div class="form-actions text-center modal-footer">
       <button type="submit" class="btn btn-default btn-flat" ng-click="$dismiss()">Cancel</button>

--- a/Web-API/client/app/common/partials/live-stream.partial.html
+++ b/Web-API/client/app/common/partials/live-stream.partial.html
@@ -1,0 +1,8 @@
+<canvas ng-click="dashboardCtrl.openFullScreen()" id="videoCanvas" class="video-fill clickable"  width="1280" height="720">
+  <p>
+    Please use a browser that supports the Canvas Element, like
+    <a href="http://www.google.com/chrome">Chrome</a>,
+    <a href="http://www.mozilla.com/firefox/">Firefox</a>,
+    <a href="http://www.apple.com/safari/">Safari</a> or Internet Explorer 10... Nottttt!
+  </p>
+</canvas>

--- a/Web-API/client/app/common/partials/live-stream.partial.html
+++ b/Web-API/client/app/common/partials/live-stream.partial.html
@@ -1,4 +1,4 @@
-<canvas ng-click="dashboardCtrl.openFullScreen()" id="videoCanvas" class="video-fill clickable"  width="1280" height="720">
+<canvas ng-click="dashboardCtrl.openFullScreen()" ng-attr-id="{{ 'videoCanvas' + liveStreamCtrl.name }}" class="video-fill clickable"  width="1280" height="720">
   <p>
     Please use a browser that supports the Canvas Element, like
     <a href="http://www.google.com/chrome">Chrome</a>,

--- a/Web-API/client/app/common/services/streamUrlManager.service.js
+++ b/Web-API/client/app/common/services/streamUrlManager.service.js
@@ -1,0 +1,35 @@
+'use strict';
+
+angular.module('webApiApp')
+  .service('streamUrlManager', streamUrlManager);
+
+function streamUrlManager($q, $http, $state, loginManager) {
+  /*jshint validthis: true */
+	var service = this;
+
+	/** Service Variables **/
+
+	/** Service Functions **/
+  service.getUrl = _getUrl;
+
+	/****** Implementation ******/
+
+  function _getUrl(obj) {
+    var deferred = $q.defer();
+
+		$http.get('api/streamUrl', {headers: {'X-Auth': loginManager.getToken()}})
+			.success(function(data) {
+				deferred.resolve(data.url);
+			})
+			.error(function(data, status) {
+				deferred.reject(status);
+			});
+
+		return deferred.promise;
+
+  }
+
+
+}
+
+

--- a/Web-API/client/app/dashboard/dashboard.controller.js
+++ b/Web-API/client/app/dashboard/dashboard.controller.js
@@ -56,6 +56,8 @@ function dashboardCtrl($scope, $rootScope, $q, $modal, $state, socket, notificat
 
   function _openFullScreen() {
     var modalInstance = $modal.open({
+      controller: 'FullScreenCtrl',
+      controllerAs: 'fullScreenCtrl',
       templateUrl: 'app/common/modals/full-screen-video.html',
       size: 'lg'
     });

--- a/Web-API/client/app/dashboard/summary/summary.controller.js
+++ b/Web-API/client/app/dashboard/summary/summary.controller.js
@@ -10,7 +10,7 @@ function summaryCtrl($scope, $rootScope, $http, $state, socket, sensorManager, l
 
   /** Controller Variables **/
   viewModel.sensors = [];
-  viewModel.streamToken = loginManager.getToken();
+  viewModel.streamToken = null;
 
   /** Controller Functions **/
   viewModel.getSensorByID = _getSensorByID;
@@ -21,6 +21,7 @@ function summaryCtrl($scope, $rootScope, $http, $state, socket, sensorManager, l
   /******** Implementation *******/
 
   function _initController() {
+    viewModel.streamToken = loginManager.getToken();
     sensorManager.getAllAndSync(viewModel);
 
     $scope.$on('$destroy', function() {

--- a/Web-API/client/app/dashboard/summary/summary.controller.js
+++ b/Web-API/client/app/dashboard/summary/summary.controller.js
@@ -3,13 +3,14 @@
 angular.module('webApiApp')
   .controller('SummaryCtrl', summaryCtrl);
 
-function summaryCtrl($scope, $rootScope, $http, $state, socket, sensorManager) {
+function summaryCtrl($scope, $rootScope, $http, $state, socket, sensorManager, loginManager) {
   /*jshint validthis: true */
   var viewModel = this;
 
 
   /** Controller Variables **/
   viewModel.sensors = [];
+  viewModel.streamToken = loginManager.getToken();
 
   /** Controller Functions **/
   viewModel.getSensorByID = _getSensorByID;

--- a/Web-API/client/app/dashboard/summary/summary.html
+++ b/Web-API/client/app/dashboard/summary/summary.html
@@ -57,7 +57,7 @@
 	  <!-- Page Content Here -->
 	  <div class="row" style=>
 			<div class="col-md-4" style="height: 40vh; width: 35vw">
-			  <live-stream token="summaryCtrl.streamToken" />	
+			  <live-stream token="summaryCtrl.streamToken" name="'summary'" />	
 			</div>
 	    <div class="col-md-6">
 	      <div class="row" style="height: 20vh; padding-top: 2vh">

--- a/Web-API/client/app/dashboard/summary/summary.html
+++ b/Web-API/client/app/dashboard/summary/summary.html
@@ -57,20 +57,7 @@
 	  <!-- Page Content Here -->
 	  <div class="row" style=>
 			<div class="col-md-4" style="height: 40vh; width: 35vw">
-				<canvas ng-click="dashboardCtrl.openFullScreen()" id="videoCanvas" class="video-fill clickable"  width="1280" height="720">
-				    <p>
-				      Please use a browser that supports the Canvas Element, like
-				      <a href="http://www.google.com/chrome">Chrome</a>,
-				      <a href="http://www.mozilla.com/firefox/">Firefox</a>,
-				      <a href="http://www.apple.com/safari/">Safari</a> or Internet Explorer 10... Nottttt!
-				    </p>
-				  </canvas>
-				  <script type="text/javascript">
-				      // Setup the WebSocket connection and start the player
-				      var client = new WebSocket( 'ws://localhost:8084/' );
-				      var canvas = document.getElementById('videoCanvas');
-				      var player = new jsmpeg(client, {canvas:canvas});
-				  </script>
+			  <live-stream token="summaryCtrl.streamToken" />	
 			</div>
 	    <div class="col-md-6">
 	      <div class="row" style="height: 20vh; padding-top: 2vh">

--- a/Web-API/client/index.html
+++ b/Web-API/client/index.html
@@ -69,12 +69,13 @@
       <!-- injector:js -->
       <script src="app/dashboard/summary/summary.controller.js"></script>
       <script src="app/app.constant.js"></script>
+      <script src="app/common/modals/sensor-notification.controller.js"></script>
       <script src="app/common/services/loginManager.service.js"></script>
       <script src="app/common/services/notificationsManager.service.js"></script>
       <script src="app/common/services/sensorManager.service.js"></script>
       <script src="app/common/services/userLogManager.service.js"></script>
       <script src="app/dashboard/dashboard.controller.js"></script>
-      <script src="app/common/modals/sensor-notification.controller.js"></script>
+      <script src="app/common/directives/live-stream.directive.js"></script>
       <script src="app/dashboard/user/user.controller.js"></script>
       <script src="app/login/login.controller.js"></script>
       <script src="components/footer/footer.directive.js"></script>

--- a/Web-API/client/index.html
+++ b/Web-API/client/index.html
@@ -74,6 +74,7 @@
       <script src="app/common/services/loginManager.service.js"></script>
       <script src="app/common/services/notificationsManager.service.js"></script>
       <script src="app/common/services/sensorManager.service.js"></script>
+      <script src="app/common/services/streamUrlManager.service.js"></script>
       <script src="app/common/services/userLogManager.service.js"></script>
       <script src="app/common/directives/live-stream.directive.js"></script>
       <script src="app/dashboard/summary/summary.controller.js"></script>

--- a/Web-API/client/index.html
+++ b/Web-API/client/index.html
@@ -67,15 +67,16 @@
     <!-- build:js(.tmp) app/app.js -->
       <script src="app/app.js"></script>
       <!-- injector:js -->
-      <script src="app/dashboard/summary/summary.controller.js"></script>
+      <script src="app/dashboard/dashboard.controller.js"></script>
       <script src="app/app.constant.js"></script>
+      <script src="app/common/modals/full-screen-video.controller.js"></script>
       <script src="app/common/modals/sensor-notification.controller.js"></script>
       <script src="app/common/services/loginManager.service.js"></script>
       <script src="app/common/services/notificationsManager.service.js"></script>
       <script src="app/common/services/sensorManager.service.js"></script>
       <script src="app/common/services/userLogManager.service.js"></script>
-      <script src="app/dashboard/dashboard.controller.js"></script>
       <script src="app/common/directives/live-stream.directive.js"></script>
+      <script src="app/dashboard/summary/summary.controller.js"></script>
       <script src="app/dashboard/user/user.controller.js"></script>
       <script src="app/login/login.controller.js"></script>
       <script src="components/footer/footer.directive.js"></script>

--- a/Web-API/package.json
+++ b/Web-API/package.json
@@ -64,6 +64,7 @@
     "grunt-newer": "^1.1.1",
     "grunt-ng-annotate": "^1.0.1",
     "grunt-ng-constant": "^1.1.0",
+    "grunt-ngrok": "^0.2.2",
     "grunt-node-inspector": "^0.4.1",
     "grunt-nodemon": "^0.4.0",
     "grunt-open": "~0.2.3",

--- a/Web-API/server/api/streamUrl/index.js
+++ b/Web-API/server/api/streamUrl/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var auth = require('../../components/authentication/auth');
+var express = require('express');
+var controller = require('./streamUrl.controller');
+
+var router = express.Router();
+
+router.get('/', auth.isAuthenticated, controller.index);
+
+module.exports = router;

--- a/Web-API/server/api/streamUrl/streamUrl.controller.js
+++ b/Web-API/server/api/streamUrl/streamUrl.controller.js
@@ -1,0 +1,25 @@
+/**
+ * Using Rails-like standard naming convention for endpoints.
+ * GET     /api/streamUrl              ->  index
+ */
+
+'use strict';
+
+import _ from 'lodash';
+import config from '../../config/environment';
+var jwt = require('jwt-simple');
+
+var secretKey = config.secrets.session;
+
+// Returns the url of the stream server 
+export function index(req, res) {
+  if (process.env['STREAMSERVER_URL']) {
+    res.status(200).json({ url: process.env['STREAMSERVER_URL'] });
+  }
+  else {
+    res.status(500).end();
+  }
+  return;
+}
+
+

--- a/Web-API/server/components/authentication/auth.js
+++ b/Web-API/server/components/authentication/auth.js
@@ -8,11 +8,30 @@ export function isAuthenticated(req,res,next) {
     var token = req.headers['x-auth'];
     var auth = jwt.decode(token, secretKey);
     User.findOneAsync({username: auth.username})
-    .then(function(user) {
-      req.user = user;
-      next();
-    });
+      .then(function(user) {
+        req.user = user;
+        next();
+      });
   } catch(err) {
     return res.sendStatus(401);
   }
+}
+
+export function isTokenValid(token) {
+  return new Promise(function(resolve, reject) {
+    try {
+      var auth = jwt.decode(token, secretKey);
+      return User.findOneAsync({username: auth.username})
+        .then(function(user) {
+          if (user) { 
+            return resolve(user)
+          }
+          else {
+            return reject('Not Authenticated');
+          }
+        });
+    } catch(err) {
+      return reject('Not Authenticated');
+    }
+  });
 }

--- a/Web-API/server/routes.js
+++ b/Web-API/server/routes.js
@@ -14,6 +14,7 @@ export default function(app) {
   app.use('/api/user', require('./api/user'));
   app.use('/api/session', require('./api/session'));
   app.use('/api/userLogs', require('./api/userLog'));
+  app.use('/api/streamUrl', require('./api/streamUrl'));
 
 
   // All undefined asset or api routes should return a 404

--- a/Web-API/server/streamer.js
+++ b/Web-API/server/streamer.js
@@ -38,6 +38,7 @@ streamer.startStreamer = function(STREAM_SECRET, STREAM_PORT, WEBSOCKET_PORT, ST
   socketServer.on('connection', function(socket) {
   	// Send magic bytes and video size to the newly connected socket
   	// struct { char magic[4]; unsigned short width, height;}
+    console.log(socket.upgradeReq.url);
   	var streamHeader = new Buffer(8);
   	streamHeader.write(STREAM_MAGIC_BYTES);
   	streamHeader.writeUInt16BE(width, 4);

--- a/Web-API/server/streamer.js
+++ b/Web-API/server/streamer.js
@@ -24,7 +24,7 @@
 
 import http from 'http';
 import ws from 'ws';
-
+import { isTokenValid } from './components/authentication/auth';
 var streamer = {}
 
 
@@ -36,20 +36,31 @@ streamer.startStreamer = function(STREAM_SECRET, STREAM_PORT, WEBSOCKET_PORT, ST
   // Websocket Server
   var socketServer = new (ws.Server)({port: WEBSOCKET_PORT});
   socketServer.on('connection', function(socket) {
-  	// Send magic bytes and video size to the newly connected socket
-  	// struct { char magic[4]; unsigned short width, height;}
-    console.log(socket.upgradeReq.url);
-  	var streamHeader = new Buffer(8);
-  	streamHeader.write(STREAM_MAGIC_BYTES);
-  	streamHeader.writeUInt16BE(width, 4);
-  	streamHeader.writeUInt16BE(height, 6);
-  	socket.send(streamHeader, {binary:true});
 
-  	console.log( 'New WebSocket Connection ('+socketServer.clients.length+' total)' );
+    function _acceptConnection() {
+      // Send magic bytes and video size to the newly connected socket
+      // struct { char magic[4]; unsigned short width, height;}
+      var streamHeader = new Buffer(8);
+      streamHeader.write(STREAM_MAGIC_BYTES);
+      streamHeader.writeUInt16BE(width, 4);
+      streamHeader.writeUInt16BE(height, 6);
+      socket.send(streamHeader, {binary:true});
 
-  	socket.on('close', function(code, message){
-  		console.log( 'Disconnected WebSocket ('+socketServer.clients.length+' total)' );
-  	});
+      console.log( 'New WebSocket Connection ('+socketServer.clients.length+' total)' );
+
+      socket.on('close', function(code, message){
+        console.log( 'Disconnected WebSocket ('+socketServer.clients.length+' total)' );
+      });
+
+    }
+
+    function _rejectConnection() {
+      console.log( 'Websocket Not Authenticated!. Closing.');
+      socket.terminate();
+    }
+
+    isTokenValid(socket.upgradeReq.url.substring(1)).then(_acceptConnection).catch(_rejectConnection);
+
   });
 
   socketServer.broadcast = function(data, opts) {


### PR DESCRIPTION
### Changes
Firstly, authentication has been added to the stream server. Now, the stream server must have the clients token in the uri or the connection will be denied. For example, to connect to the stream you would have the following link:
`ws://<STREAMSERVER_URL>/<CLIENT_TOKEN>`

Additionally, this PR will have grunt start opening Ngrok tunnels for us. Thus, when we start `grunt serve` ngrok tunnels will be opened to connect our local web and stream server to an actual website. 

After startup, grunt will set the `STREAMSERVER_URL` based on where ngrok opens up our stream server tunnel. The api will then read this environment variable and send it to the client, so the client knows where to get the stream from.